### PR TITLE
Refactor/post : querydsl 게시물 조회(페이징, 단건조회)

### DIFF
--- a/src/main/java/project/como/domain/image/model/Image.java
+++ b/src/main/java/project/como/domain/image/model/Image.java
@@ -21,7 +21,7 @@ public class Image {
 	@Id @Column(name = "image_id")
 	private Long id;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JsonIgnore
 	private Post post;
 

--- a/src/main/java/project/como/domain/image/model/Image.java
+++ b/src/main/java/project/como/domain/image/model/Image.java
@@ -1,4 +1,4 @@
-package project.como.domain.post.model;
+package project.como.domain.image.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import project.como.domain.post.model.Post;
 
 import static jakarta.persistence.GenerationType.*;
 
@@ -14,15 +15,15 @@ import static jakarta.persistence.GenerationType.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Tech {
+public class Image {
 
 	@GeneratedValue(strategy = IDENTITY)
-	@Id @Column(name = "tech_id")
+	@Id @Column(name = "image_id")
 	private Long id;
 
 	@ManyToOne
 	@JsonIgnore
 	private Post post;
 
-	private String stack;
+	private String url;
 }

--- a/src/main/java/project/como/domain/image/repository/ImageRepository.java
+++ b/src/main/java/project/como/domain/image/repository/ImageRepository.java
@@ -1,0 +1,14 @@
+package project.como.domain.image.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import project.como.domain.image.model.Image;
+
+import java.util.List;
+
+@Repository
+public interface ImageRepository extends JpaRepository<Image, Long> {
+	List<Image> findAllByPostId(Long postId);
+
+	void deleteAllByUrlIn(List<String> urls);
+}

--- a/src/main/java/project/como/domain/post/controller/PostController.java
+++ b/src/main/java/project/como/domain/post/controller/PostController.java
@@ -50,10 +50,10 @@ public class PostController {
 	@Logging(item = "Post", action = "get")
 	@GetMapping("/posts")
 	public ResponseEntity<PostsResponseDto> getPostsByCategory(@RequestParam(required = false) String category,
-			@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo,
-            Pageable pageable) {
+			@RequestParam(required = false) List<String> stacks,
+			@RequestParam(required = false, defaultValue = "0", value = "page") int pageNo) {
 		pageNo = (pageNo == 0) ? 0 : (pageNo - 1);
-		PostsResponseDto dto = postService.getPostsByCategory(pageable, pageNo, category);
+		PostsResponseDto dto = postService.getPostsByCategory(pageNo, category, stacks);
 
 		return ResponseEntity.ok().body(dto);
 	}

--- a/src/main/java/project/como/domain/post/dto/PostCreateRequestDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostCreateRequestDto.java
@@ -20,5 +20,5 @@ public class PostCreateRequestDto {
 	@NotNull(message = "카테고리를 선택해주세요.")
 	private Category category;
 	@NotNull(message = "기술스택을 선택해주세요.")
-	private List<Tech> techs;
+	private List<String> techs;
 }

--- a/src/main/java/project/como/domain/post/dto/PostDetailResponseDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostDetailResponseDto.java
@@ -2,6 +2,7 @@ package project.como.domain.post.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
+import project.como.domain.image.model.Image;
 import project.como.domain.post.model.Category;
 import project.como.domain.post.model.PostState;
 import project.como.domain.post.model.Tech;
@@ -11,28 +12,28 @@ import java.util.List;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PostDetailResponseDto {
 	private Long id;
 	private String title;
 	private String body;
 	private Category category;
 	private PostState state;
-	private List<Tech> techs;
+	private List<String> techs;
 	private List<String> images;
 	private Long heartCount;
 
-	public PostDetailResponseDto() {
-	}
-
-	@QueryProjection
-	public PostDetailResponseDto(Long id, String title, String body, Category category, PostState state, List<Tech> techs, List<String> images, Long heartCount) {
-		this.id = id;
-		this.title = title;
-		this.body = body;
-		this.category = category;
-		this.state = state;
-		this.techs = null;
-		this.images = images;
-		this.heartCount = heartCount;
-	}
+//	public PostDetailResponseDto() {
+//	}
+//
+//	@QueryProjection
+//	public PostDetailResponseDto(Long id, String title, String body, Category category, PostState state, Long heartCount) {
+//		this.id = id;
+//		this.title = title;
+//		this.body = body;
+//		this.category = category;
+//		this.state = state;
+//		this.heartCount = heartCount;
+//	}
 }

--- a/src/main/java/project/como/domain/post/dto/PostModifyRequestDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostModifyRequestDto.java
@@ -16,6 +16,6 @@ public class PostModifyRequestDto {
 	private String body;
 	private Category category;
 	private PostState state;
-	private List<Tech> techs;
+	private List<String> techs;
 	List<@NotBlank @URL String> oldUrls;
 }

--- a/src/main/java/project/como/domain/post/dto/PostPagingResponseDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostPagingResponseDto.java
@@ -1,17 +1,18 @@
 package project.como.domain.post.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 import project.como.domain.post.model.Category;
 import project.como.domain.post.model.PostState;
 import project.como.domain.post.model.Tech;
 
 import java.util.List;
 
-
 @Data
-@Builder
-public class PostDetailResponseDto {
+@NoArgsConstructor
+public class PostPagingResponseDto {
 	private Long id;
 	private String title;
 	private String body;
@@ -21,17 +22,14 @@ public class PostDetailResponseDto {
 	private List<String> images;
 	private Long heartCount;
 
-	public PostDetailResponseDto() {
-	}
-
 	@QueryProjection
-	public PostDetailResponseDto(Long id, String title, String body, Category category, PostState state, List<Tech> techs, List<String> images, Long heartCount) {
+	public PostPagingResponseDto(Long id, String title, String body, Category category, PostState state, List<Tech> techs, List<String> images, Long heartCount) {
 		this.id = id;
 		this.title = title;
 		this.body = body;
 		this.category = category;
 		this.state = state;
-		this.techs = null;
+		this.techs = techs;
 		this.images = images;
 		this.heartCount = heartCount;
 	}

--- a/src/main/java/project/como/domain/post/dto/PostPagingResponseDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostPagingResponseDto.java
@@ -2,6 +2,7 @@ package project.como.domain.post.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import project.como.domain.post.model.Category;
@@ -11,26 +12,14 @@ import project.como.domain.post.model.Tech;
 import java.util.List;
 
 @Data
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class PostPagingResponseDto {
 	private Long id;
 	private String title;
-	private String body;
 	private Category category;
 	private PostState state;
-	private List<Tech> techs;
-	private List<String> images;
+	private List<String> techs;
 	private Long heartCount;
-
-	@QueryProjection
-	public PostPagingResponseDto(Long id, String title, String body, Category category, PostState state, List<Tech> techs, List<String> images, Long heartCount) {
-		this.id = id;
-		this.title = title;
-		this.body = body;
-		this.category = category;
-		this.state = state;
-		this.techs = techs;
-		this.images = images;
-		this.heartCount = heartCount;
-	}
 }

--- a/src/main/java/project/como/domain/post/dto/PostTechsDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostTechsDto.java
@@ -1,0 +1,22 @@
+package project.como.domain.post.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import project.como.domain.post.model.Tech;
+
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+public class PostTechsDto {
+	private Long postId;
+	private List<Tech> techs;
+
+	@QueryProjection
+	public PostTechsDto(Long postId, List<Tech> techs) {
+		this.postId = postId;
+		this.techs = techs;
+	}
+}

--- a/src/main/java/project/como/domain/post/dto/PostsResponseDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostsResponseDto.java
@@ -13,5 +13,5 @@ public class PostsResponseDto {
 	private int totalPages;
 	private long totalElements;
 	private int currentPage;
-	private List<PostDetailResponseDto> posts;
+	private List<PostPagingResponseDto> posts;
 }

--- a/src/main/java/project/como/domain/post/exception/PostImageCountExceededException.java
+++ b/src/main/java/project/como/domain/post/exception/PostImageCountExceededException.java
@@ -1,0 +1,10 @@
+package project.como.domain.post.exception;
+
+import project.como.global.common.exception.ComoException;
+import project.como.global.common.exception.ErrorType;
+
+public class PostImageCountExceededException extends ComoException.ServerErrorException {
+	public PostImageCountExceededException() {
+		super(ErrorType.ServerError.EXCEEDED_TOTAL_FILE_COUNT, "파일 최대 개수인 5개를 초과했습니다.");
+	}
+}

--- a/src/main/java/project/como/domain/post/model/Heart.java
+++ b/src/main/java/project/como/domain/post/model/Heart.java
@@ -15,8 +15,8 @@ import static jakarta.persistence.GenerationType.*;
 @AllArgsConstructor
 public class Heart {
 
+	@Id
 	@GeneratedValue(strategy = IDENTITY)
-	@Id @Column(name = "heart_id")
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/project/como/domain/post/model/Post.java
+++ b/src/main/java/project/como/domain/post/model/Post.java
@@ -1,6 +1,7 @@
 package project.como.domain.post.model;
 
 import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -10,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.*;
 import org.springframework.web.multipart.MultipartFile;
 import project.como.domain.comment.model.Comment;
+import project.como.domain.image.model.Image;
 import project.como.domain.user.model.User;
 import project.como.global.common.model.BaseTimeEntity;
 
@@ -26,6 +28,7 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
+@BatchSize(size = 1000)
 public class Post extends BaseTimeEntity {
 
 	@GeneratedValue(strategy = IDENTITY)
@@ -44,13 +47,19 @@ public class Post extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private Category category;
 
-	@ElementCollection(fetch = FetchType.LAZY)
-	@Enumerated(EnumType.STRING)
-	@CollectionTable(name = "post_techs", joinColumns = @JoinColumn(name = "post_post_id"))
+//	@ElementCollection(fetch = FetchType.EAGER)
+//	@Enumerated(EnumType.STRING)
+//	@CollectionTable(name = "post_techs", joinColumns = @JoinColumn(name = "post_post_id"))
+//	private List<Tech> techs;
+
+	@OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<Tech> techs;
 
-	@ElementCollection(fetch = FetchType.LAZY)
-	private List<String> images;
+	@OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<Image> images;
+
+//	@ElementCollection(fetch = FetchType.EAGER)
+//	private List<String> images;
 
 	@NotBlank
 	private String title;
@@ -70,10 +79,6 @@ public class Post extends BaseTimeEntity {
 		this.body = body;
 	}
 
-	public void modifyTechs(List<Tech> techs) {
-		this.techs = techs;
-	}
-
 	public void modifyCategory(Category category) {
 		this.category = category;
 	}
@@ -88,11 +93,6 @@ public class Post extends BaseTimeEntity {
 
 	public void countHeart() { ++this.heartCount; }
 	public void discountHeart() { --this.heartCount; }
-
-	public void setImages(List<String> uploadedImages) {
-		if (this.images == null) this.images = new LinkedList<>();
-		images.addAll(uploadedImages);
-	}
 
 	@OneToMany(mappedBy = "post")
 	private Collection<Comment> comment;

--- a/src/main/java/project/como/domain/post/model/Post.java
+++ b/src/main/java/project/como/domain/post/model/Post.java
@@ -44,11 +44,12 @@ public class Post extends BaseTimeEntity {
 	@Enumerated(EnumType.STRING)
 	private Category category;
 
-	@Column(nullable = false)
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection(fetch = FetchType.LAZY)
+	@Enumerated(EnumType.STRING)
+	@CollectionTable(name = "post_techs", joinColumns = @JoinColumn(name = "post_post_id"))
 	private List<Tech> techs;
 
-	@ElementCollection(fetch = FetchType.EAGER)
+	@ElementCollection(fetch = FetchType.LAZY)
 	private List<String> images;
 
 	@NotBlank

--- a/src/main/java/project/como/domain/post/model/Tech.java
+++ b/src/main/java/project/como/domain/post/model/Tech.java
@@ -20,8 +20,8 @@ public class Tech {
 	@Id @Column(name = "tech_id")
 	private Long id;
 
-	@ManyToOne
 	@JsonIgnore
+	@ManyToOne(fetch = FetchType.LAZY)
 	private Post post;
 
 	private String stack;

--- a/src/main/java/project/como/domain/post/model/Tech.java
+++ b/src/main/java/project/como/domain/post/model/Tech.java
@@ -1,7 +1,9 @@
 package project.como.domain.post.model;
 
+import jakarta.persistence.Entity;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
@@ -39,5 +41,6 @@ public enum Tech {
 	Jest("Jest"),
 	C("C");
 
-	private String stack;
+	private final String stack;
+
 }

--- a/src/main/java/project/como/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/project/como/domain/post/repository/PostCustomRepository.java
@@ -12,5 +12,5 @@ import java.util.List;
 
 public interface PostCustomRepository {
 
-	Page<PostDetailResponseDto> findAllByCategoryAndTechs(Category category, List<Tech> techs, Pageable pageable);
+	Page<PostPagingResponseDto> findAllByCategoryAndTechs(Category category, List<String> stacks, Pageable pageable);
 }

--- a/src/main/java/project/como/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/project/como/domain/post/repository/PostCustomRepository.java
@@ -1,0 +1,16 @@
+package project.como.domain.post.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import project.como.domain.post.dto.PostDetailResponseDto;
+import project.como.domain.post.dto.PostPagingResponseDto;
+import project.como.domain.post.model.Category;
+import project.como.domain.post.model.Post;
+import project.como.domain.post.model.Tech;
+
+import java.util.List;
+
+public interface PostCustomRepository {
+
+	Page<PostDetailResponseDto> findAllByCategoryAndTechs(Category category, List<Tech> techs, Pageable pageable);
+}

--- a/src/main/java/project/como/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/project/como/domain/post/repository/PostCustomRepositoryImpl.java
@@ -32,7 +32,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
 	public Page<PostPagingResponseDto> findAllByCategoryAndTechs(Category category, List<String> stacks, Pageable pageable) {
 		List<Post> tmp_posts = queryFactory.selectFrom(post)
-				.join(post.techs)
+				.join(post.techs).fetchJoin()
 				.where(categoryEq(category)
 						.and(containsTechs(stacks)))
 				.orderBy(post.createdDate.desc())
@@ -63,7 +63,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
 	public PostDetailResponseDto findPostDetailById(Long id) {
 		Post result = queryFactory.selectFrom(post)
-				.join(post.techs, tech)
+				.join(post.techs, tech).fetchJoin()
 				.leftJoin(post.images, image)
 				.where(post.id.eq(id))
 				.fetchOne();
@@ -74,7 +74,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 				.body(result.getBody())
 				.category(result.getCategory())
 				.state(result.getState())
-				.techs(result.getTechs().stream().map(Tech::getStack).collect(Collectors.toList()))
+				.techs(result.getTechs().stream().map(Tech::getStack).distinct().collect(Collectors.toList()))
 				.images(result.getImages().stream().map(Image::getUrl).collect(Collectors.toList()))
 				.heartCount(result.getHeartCount())
 				.build();

--- a/src/main/java/project/como/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/project/como/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,0 +1,148 @@
+package project.como.domain.post.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import project.como.domain.post.dto.*;
+import project.como.domain.post.model.Category;
+import project.como.domain.post.model.Post;
+import project.como.domain.post.model.Tech;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static project.como.domain.post.model.QPost.*;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class PostCustomRepositoryImpl implements PostCustomRepository {
+	private final JPAQueryFactory queryFactory;
+
+	public Page<PostDetailResponseDto> findAllByCategoryAndTechs(Category category, List<Tech> techs, Pageable pageable) {
+
+		List<PostDetailResponseDto> content = queryFactory.select(
+					new QPostDetailResponseDto(
+							post.id,
+							post.title,
+							post.body,
+							post.category,
+							post.state,
+							post.techs,
+							post.images,
+							post.heartCount)
+				)
+				.from(post)
+				.orderBy(post.createdDate.desc())
+				.fetch();
+
+//		Map<Long, List<PostTechsDto>> postTechsMap = postIdToPostTechsDtoMap(content);
+
+
+
+//		content.forEach(dto -> dto.setTechs(postTechsMap.get(dto.getId())));
+
+//		for (PostPagingResponseDto dto : content) {
+//			List<PostTechsDto> postTechsDtos = postTechsMap.get(dto.getId());
+//			for (PostTechsDto techDto : postTechsDtos) {
+//				techList.add(techDto.getTechs().get);
+//			}
+//			dto.setTechs(postTechsMap.get(dto.getId()));
+//		}
+
+		int count = queryFactory.selectFrom(post)
+				.where(categoryEq(category))
+				.fetch().size();
+
+		return new PageImpl<>(content, pageable, count);
+	}
+
+	public Page<PostDetailResponseDto> findAll(Category category, List<Tech> techs, Pageable pageable) {
+		List<Post> content = queryFactory.selectFrom(post)
+				.where(categoryEq(category)
+						.and(containsTechs(techs)))
+				.fetch();
+
+		List<PostDetailResponseDto> result = content.stream().map(post -> {
+			PostDetailResponseDto dto = new PostDetailResponseDto();
+			dto.setId(post.getId());
+			dto.setTitle(post.getTitle());
+			dto.setBody(post.getBody());
+			dto.setCategory(post.getCategory());
+			dto.setState(post.getState());
+			dto.setTechs(post.getTechs());
+			dto.setImages(post.getImages());
+			dto.setHeartCount(post.getHeartCount());
+			return dto;
+		}).toList();
+
+		int count = queryFactory.selectFrom(post)
+				.where(categoryEq(category)
+						.and(containsTechs(techs)))
+				.fetch().size();
+
+		return new PageImpl<>(result, pageable, count);
+	}
+
+	private Map<Long, List<PostTechsDto>> postIdToPostTechsDtoMap(List<PostPagingResponseDto> content) {
+		List<Long> postIds = content.stream()
+				.map(PostPagingResponseDto::getId)
+				.toList();
+
+		List<PostTechsDto> postTechsDto = queryFactory.select(
+						new QPostTechsDto(
+								post.id,
+								post.techs
+						)
+				).from(post)
+				.where(post.id.in(postIds))
+				.fetch();
+
+		return postTechsDto.stream()
+				.collect(Collectors.groupingBy(PostTechsDto::getPostId));
+	}
+
+	public PostDetailResponseDto findPostDetailById(Long id) {
+		return queryFactory.select(
+				new QPostDetailResponseDto(
+						post.id,
+						post.title,
+						post.body,
+						post.category,
+						post.state,
+						post.techs,
+						post.images,
+						post.heartCount)
+				)
+				.from(post)
+				.where(post.id.eq(id))
+				.fetchOne();
+	}
+
+	private BooleanExpression categoryEq(Category category) {
+		return category != null ? post.category.eq(category) : null;
+	}
+
+	private BooleanBuilder containsTechs(List<Tech> techs) {
+		BooleanBuilder builder = new BooleanBuilder();
+
+		if (techs == null || techs.isEmpty()) return builder;
+
+		for (Tech tech : techs) {
+			builder.and(post.techs.contains(tech));
+		}
+
+		return builder;
+	}
+}

--- a/src/main/java/project/como/domain/post/repository/PostRepository.java
+++ b/src/main/java/project/como/domain/post/repository/PostRepository.java
@@ -7,11 +7,16 @@ import org.springframework.data.jpa.repository.Query;
 import project.como.domain.post.model.Category;
 import project.como.domain.post.model.Post;
 import project.como.domain.post.model.PostState;
+import project.como.domain.post.model.Tech;
+
+import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
-//	@Query(value = "SELECT * FROM POST p ORDER BY p.created_date DESC")
-	Page<Post> findAllByOrderByCreatedDateDesc(Pageable pageable);
-	Page<Post> findAllByCategoryOrderByCreatedDateDesc(Category category, Pageable pageable);
+	@Query("SELECT p FROM Post p WHERE (:stacks IS NULL OR :stacks MEMBER OF p.techs) ORDER BY p.createdDate DESC")
+	Page<Post> findAllByOrderByCreatedDateDesc(List<Tech> stacks, Pageable pageable);
+
+	@Query("SELECT p FROM Post p WHERE p.category = :category AND (:stacks IS NULL OR :stacks MEMBER OF p.techs) ORDER BY p.createdDate DESC")
+	Page<Post> findAllByCategoryOrderByCreatedDateDesc(Category category, List<Tech> stacks, Pageable pageable);
 	Page<Post> findAllByCategoryAndStateOrderByCreatedDate(Category category, PostState state, Pageable pageable);
 
 }

--- a/src/main/java/project/como/domain/post/repository/TechRepository.java
+++ b/src/main/java/project/como/domain/post/repository/TechRepository.java
@@ -1,0 +1,14 @@
+package project.como.domain.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import project.como.domain.post.model.Tech;
+
+import java.util.List;
+
+@Repository
+public interface TechRepository extends JpaRepository<Tech, Long> {
+	List<Tech> findAllByPostId(Long postId);
+
+	void deleteAllByPostId(Long postId);
+}

--- a/src/main/java/project/como/domain/user/model/User.java
+++ b/src/main/java/project/como/domain/user/model/User.java
@@ -22,7 +22,6 @@ import static jakarta.persistence.GenerationType.*;
 public class User implements UserDetails {
 
 	@Id
-	@Column(name = "user_id")
 	@GeneratedValue(strategy = IDENTITY)
 	private Long id;
 

--- a/src/main/java/project/como/global/common/exception/ComoControllerAdvice.java
+++ b/src/main/java/project/como/global/common/exception/ComoControllerAdvice.java
@@ -1,26 +1,12 @@
 package project.como.global.common.exception;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-import project.como.domain.comment.exception.CommentForbiddenAccessException;
-import project.como.domain.comment.exception.CommentLevelExceedException;
-import project.como.domain.comment.exception.CommentNotFoundException;
-import project.como.domain.image.exception.DeleteInvalidImageException;
-import project.como.domain.image.exception.FileDeleteException;
-import project.como.domain.image.exception.FileUploadException;
-import project.como.domain.image.exception.UnsupportedFileExtensionException;
-import project.como.domain.post.exception.*;
-import project.como.domain.user.exception.UserInfoNotFoundException;
-import project.como.domain.user.exception.UserNotEligibleForApplyException;
 import project.como.global.auth.exception.ComoLoginFailureException;
 import project.como.global.common.dto.ErrorResponse;
-import project.como.global.common.dto.ExceptionResponse;
-
-import java.time.LocalDateTime;
 
 import static org.springframework.http.HttpStatus.*;
 import static project.como.global.common.exception.ComoException.*;

--- a/src/main/java/project/como/global/common/exception/ErrorType.java
+++ b/src/main/java/project/como/global/common/exception/ErrorType.java
@@ -113,7 +113,8 @@ public interface ErrorType {
 		SERVER_ERROR_DEFAULT(5000),
 
 		FILE_UPLOAD_FAIL(5001),
-		FILE_DELETE_FAIL(5002)
+		FILE_DELETE_FAIL(5002),
+		EXCEEDED_TOTAL_FILE_COUNT(5003)
 		;
 
 		private final int errorCode;

--- a/src/main/java/project/como/global/config/SecurityConfig.java
+++ b/src/main/java/project/como/global/config/SecurityConfig.java
@@ -56,6 +56,7 @@ public class SecurityConfig {
 				.requestMatchers(new AntPathRequestMatcher("/user/check-duplicate/{username}")).permitAll()
 				.requestMatchers(new AntPathRequestMatcher("/user/current-user")).permitAll()
 				.requestMatchers(new AntPathRequestMatcher("/api/v1/post")).permitAll()
+				.requestMatchers(new AntPathRequestMatcher("/api/v1/posts")).permitAll()
 				.requestMatchers(new AntPathRequestMatcher("/HOST/**")).hasRole("어드민")
 				.anyRequest().authenticated()
 				.and()

--- a/src/test/java/project/como/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/project/como/domain/post/controller/PostControllerTest.java
@@ -21,6 +21,7 @@ import project.como.domain.post.service.PostService;
 import project.como.domain.user.model.User;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -82,9 +83,10 @@ class PostControllerTest {
 	@DisplayName("게시물 카테고리별 조회")
 	void getPostsByCategory() {
 		final String CATEGORY = "Study";
+		final List<String> STACKS = List.of("Java", "Spring");
 		Pageable pageable = PageRequest.of(0, 5);
 
-		PostsResponseDto dto = postService.getPostsByCategory(pageable, 0, CATEGORY);
+		PostsResponseDto dto = postService.getPostsByCategory(0, CATEGORY, STACKS);
 
 		assertThat(dto.getTotalElements()).isEqualTo(3);
 		assertThat(dto.getPosts().get(0).getTitle()).isEqualTo("test title");


### PR DESCRIPTION
## 개요
<!--- 변경  사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->
게시물 조회에 대한 동적쿼리의 필요성으로 querydsl 도입 및 페이징, 단건 조회 querydsl을 사용한 조회로 변경
1. 페이징에서 dto로 반환하는데 Projections 를 사용한 Dto 직접 추출에 애로사항이 있어 차후에 개선 사항이 있음
2. 페이징에서 중복 쿼리에 대한 offset, limit에 대한 Post 개수 설정에 버그가 있어 이 또한 해결해야 할 부분이 있음

### 제일 중요한 부분
Post 엔티티에서 기존에는 Tech의 여러개의 기술 스택, Image의 여러개의 이미지를 @ElementCollection으로 관리했었음.
하지만 querydsl을 사용할 때 join과 N+1문제를 컨트롤할 수 없는 문제가 있어서 이를 엔티티로 분리하게 됨.
엔티티로 분리한 이후에 해당 문제를 해결할 수 있었음.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention](https://jane-aeiou.tistory.com/93) 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
