### PR TITLE
Refactor/post : 자신이 작성한 게시물 조회하는 기능

### DIFF
--- a/src/main/java/project/como/domain/post/controller/PostController.java
+++ b/src/main/java/project/como/domain/post/controller/PostController.java
@@ -60,6 +60,7 @@ public class PostController {
 
 
 
+	@Logging(item = "Post", action = "get")
 	@GetMapping("/posts/myself")
 	public ResponseEntity<PostsResponseDto> getPostsByMyself(@CurrentUser String username,
 	                                                         @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo) {

--- a/src/main/java/project/como/domain/post/controller/PostController.java
+++ b/src/main/java/project/como/domain/post/controller/PostController.java
@@ -58,6 +58,17 @@ public class PostController {
 		return ResponseEntity.ok().body(dto);
 	}
 
+
+
+	@GetMapping("/posts/myself")
+	public ResponseEntity<PostsResponseDto> getPostsByMyself(@CurrentUser String username,
+	                                                         @RequestParam(required = false, defaultValue = "0", value = "page") int pageNo) {
+		pageNo = (pageNo == 0) ? 0 : (pageNo - 1);
+		PostsResponseDto dto = postService.getPostsByMyself(username, pageNo);
+
+		return ResponseEntity.ok().body(dto);
+	}
+
 	@Logging(item = "Post", action = "patch")
 	@PatchMapping(value = "/post/modify", consumes = {"application/json", "multipart/form-data"})
 	public ResponseEntity<String> modifyPost(@CurrentUser String username,

--- a/src/main/java/project/como/domain/post/repository/PostRepository.java
+++ b/src/main/java/project/como/domain/post/repository/PostRepository.java
@@ -1,5 +1,6 @@
 package project.como.domain.post.repository;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,6 +9,7 @@ import project.como.domain.post.model.Category;
 import project.como.domain.post.model.Post;
 import project.como.domain.post.model.PostState;
 import project.como.domain.post.model.Tech;
+import project.como.domain.user.model.User;
 
 import java.util.List;
 
@@ -19,5 +21,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 	Page<Post> findAllByCategoryOrderByCreatedDateDesc(Category category, List<Tech> stacks, Pageable pageable);
 	Page<Post> findAllByCategoryAndStateOrderByCreatedDate(Category category, PostState state, Pageable pageable);
 
+	@Query(value = "SELECT p FROM Post p JOIN FETCH p.techs WHERE p.user = :user ORDER BY p.createdDate DESC",
+	countQuery = "SELECT COUNT(p) FROM Post p WHERE p.user = :user")
+	Page<Post> findAllByUserOrderByCreatedDateDesc(@Param("user") User user, Pageable pageable);
 }
 

--- a/src/main/java/project/como/domain/post/service/PostService.java
+++ b/src/main/java/project/como/domain/post/service/PostService.java
@@ -24,6 +24,7 @@ import project.como.domain.post.repository.TechRepository;
 import project.como.domain.user.exception.UserNotFoundException;
 import project.como.domain.user.model.User;
 import project.como.domain.user.repository.UserRepository;
+import project.como.global.auth.exception.UnauthorizedException;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -145,6 +146,26 @@ public class PostService {
 				.totalElements(postPage.getTotalElements())
 				.currentPage(postPage.getNumber())
 				.posts(postPage.getContent())
+				.build();
+	}
+
+	public PostsResponseDto getPostsByMyself(String username, int pageNo) {
+		User user = userRepository.findByUsername(username).orElseThrow(UnauthorizedException::new);
+
+		Page<Post> postPage = postRepository.findAllByUserOrderByCreatedDateDesc(user, PageRequest.of(pageNo, TOTAL_ITEMS_PER_PAGE));
+
+		return PostsResponseDto.builder()
+				.totalPages(postPage.getTotalPages())
+				.totalElements(postPage.getTotalElements())
+				.currentPage(postPage.getNumber())
+				.posts(postPage.stream().map(p -> PostPagingResponseDto.builder()
+						.id(p.getId())
+						.title(p.getTitle())
+						.category(p.getCategory())
+						.state(p.getState())
+						.techs(p.getTechs().stream().map(Tech::getStack).toList())
+						.heartCount(p.getHeartCount())
+						.build()).toList())
 				.build();
 	}
 


### PR DESCRIPTION
## 개요
<!--- 변경  사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
자신이 작성한 게시물 조회하는 기능
1. Spring data JPA 사용

### 배운 점
상황 : Spring data JPA Repository에서 @Query를 이용해 fetch join을 시도하려 했는데 query specified join fetching, but the owner of the fetched association was not present in the select list 에러 발생

원인 : Hibernate에서 fetch join 사용 시, paging에 필요한 count query를 자동으로 생성해주지 못함. 그래서 @Query("쿼리문", countQuery = "카운트 쿼리문") 으로 선언해주면 해결


<!---- Resolves: #(Issue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention](https://jane-aeiou.tistory.com/93) 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
