### PR TITLE
[Refactor/post] 게시물 조회수 구현, Redis를 이용하여 조회수 중복 카운팅 방지

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bin/
 *.iml
 *.ipr
 **/*.yml
+**/*.properties
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/

--- a/src/main/java/project/como/domain/post/controller/PostController.java
+++ b/src/main/java/project/como/domain/post/controller/PostController.java
@@ -41,8 +41,9 @@ public class PostController {
 
 	@Logging(item = "Post", action = "get")
 	@GetMapping("/{post_id}")
-	public ResponseEntity<PostDetailResponseDto> getDetailPost(@PathVariable(value = "post_id", required = true) Long postId) {
-		PostDetailResponseDto dto = postService.getById(postId);
+	public ResponseEntity<PostDetailResponseDto> getDetailPost(@CurrentUser String username,
+															   @PathVariable(value = "post_id", required = true) Long postId) {
+		PostDetailResponseDto dto = postService.getById(postId, username);
 
 		return ResponseEntity.ok().body(dto);
 	}

--- a/src/main/java/project/como/domain/post/dto/PostDetailResponseDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostDetailResponseDto.java
@@ -13,6 +13,7 @@ import java.util.List;
 @AllArgsConstructor
 public class PostDetailResponseDto {
 	private Long id;
+	private String createdDate;
 	private String title;
 	private String body;
 	private Category category;

--- a/src/main/java/project/como/domain/post/dto/PostDetailResponseDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostDetailResponseDto.java
@@ -20,6 +20,7 @@ public class PostDetailResponseDto {
 	private List<String> techs;
 	private List<String> images;
 	private Long heartCount;
+	private Long readCount;
 
 //	public PostDetailResponseDto() {
 //	}

--- a/src/main/java/project/como/domain/post/dto/PostPagingResponseDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostPagingResponseDto.java
@@ -15,6 +15,7 @@ import java.util.List;
 @AllArgsConstructor
 public class PostPagingResponseDto {
 	private Long id;
+	private String createdDate;
 	private String title;
 	private Category category;
 	private PostState state;

--- a/src/main/java/project/como/domain/post/dto/PostPagingResponseDto.java
+++ b/src/main/java/project/como/domain/post/dto/PostPagingResponseDto.java
@@ -20,4 +20,5 @@ public class PostPagingResponseDto {
 	private PostState state;
 	private List<String> techs;
 	private Long heartCount;
+	private Long readCount;
 }

--- a/src/main/java/project/como/domain/post/model/Post.java
+++ b/src/main/java/project/como/domain/post/model/Post.java
@@ -60,6 +60,7 @@ public class Post extends BaseTimeEntity {
 	private String title;
 
 	@NotBlank
+	@Column(columnDefinition = "TEXT")
 	private String body;
 
 	private Long readCount;

--- a/src/main/java/project/como/domain/post/repository/PostCustomRepository.java
+++ b/src/main/java/project/como/domain/post/repository/PostCustomRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface PostCustomRepository {
 
 	Page<PostPagingResponseDto> findAllByCategoryAndTechs(Category category, List<String> stacks, Pageable pageable);
-	PostDetailResponseDto findPostDetailById(Long id);
+	PostDetailResponseDto findPostDetailById(Long id, String username);
 }

--- a/src/main/java/project/como/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/project/como/domain/post/repository/PostCustomRepositoryImpl.java
@@ -44,6 +44,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 			dto.setState(post.getState());
 			dto.setTechs(post.getTechList().stream().map((pt) -> pt.getTech().getStack()).toList());
 			dto.setHeartCount(post.getHeartCount());
+			dto.setReadCount(post.getReadCount());
 			return dto;
 		}).toList();
 
@@ -63,6 +64,8 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 				.where(post.id.eq(id))
 				.fetchOne();
 
+		if (result != null) result.countRead();
+
 		return PostDetailResponseDto.builder()
 				.id(result.getId())
 				.title(result.getTitle())
@@ -72,6 +75,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 				.techs(result.getTechList().stream().distinct().map((t) -> t.getTech().getStack()).sorted().toList())
 				.images(result.getImages().stream().map(Image::getUrl).collect(Collectors.toList()))
 				.heartCount(result.getHeartCount())
+				.readCount(result.getReadCount())
 				.build();
 	}
 

--- a/src/main/java/project/como/domain/post/repository/PostCustomRepositoryImpl.java
+++ b/src/main/java/project/como/domain/post/repository/PostCustomRepositoryImpl.java
@@ -1,5 +1,6 @@
 package project.como.domain.post.repository;
 
+import static java.time.format.DateTimeFormatter.*;
 import static project.como.domain.image.model.QImage.image;
 import static project.como.domain.post.model.QPost.post;
 import static project.como.domain.post.model.QPostTech.postTech;
@@ -7,7 +8,6 @@ import static project.como.domain.post.model.QPostTech.postTech;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +42,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 		List<PostPagingResponseDto> content = posts.stream().map(post -> {
 			PostPagingResponseDto dto = new PostPagingResponseDto();
 			dto.setId(post.getId());
+			dto.setCreatedDate(post.getCreatedDate().format(ISO_LOCAL_DATE));
 			dto.setTitle(post.getTitle());
 			dto.setCategory(post.getCategory());
 			dto.setState(post.getState());
@@ -77,6 +78,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
 
 		return PostDetailResponseDto.builder()
 				.id(result.getId())
+				.createdDate(result.getCreatedDate().format(ISO_LOCAL_DATE))
 				.title(result.getTitle())
 				.body(result.getBody())
 				.category(result.getCategory())

--- a/src/main/java/project/como/domain/post/service/PostService.java
+++ b/src/main/java/project/como/domain/post/service/PostService.java
@@ -147,8 +147,8 @@ public class PostService {
 		postRepository.delete(post);
 	}
 
-	public PostDetailResponseDto getById(Long postId) {
-		PostDetailResponseDto dto = postCustomRepository.findPostDetailById(postId);
+	public PostDetailResponseDto getById(Long postId, String username) {
+		PostDetailResponseDto dto = postCustomRepository.findPostDetailById(postId, username);
 
 		log.info("dto : {}", dto);
 		return dto;

--- a/src/main/java/project/como/domain/post/service/PostService.java
+++ b/src/main/java/project/como/domain/post/service/PostService.java
@@ -63,6 +63,7 @@ public class PostService {
 	private final PostTechRepository postTechRepository;
 	private final ApplyService applyService;
 
+	@Transactional
 	public String create(String username, PostCreateRequestDto dto, @Nullable List<MultipartFile> images) {
 		User user = userRepository.findByUsername(username).orElseThrow(UserNotFoundException::new);
 
@@ -86,6 +87,7 @@ public class PostService {
 		return postRepository.save(newPost).getId().toString();
 	}
 
+	@Transactional
 	public void modify(String username, PostModifyRequestDto dto, List<MultipartFile> images) {
 		Post post = postRepository.findById(dto.getPostId()).orElseThrow(() -> new PostNotFoundException(dto.getPostId()));
 		User user = userRepository.findByUsername(username).orElseThrow(UserNotFoundException::new);
@@ -129,6 +131,7 @@ public class PostService {
 		if (dto.getOldUrls() != null) imageService.deleteImages(dto.getOldUrls());
 	}
 
+	@Transactional
 	public void deleteById(String username, Long postId) {
 		Post post = postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException(postId));
 		User user = userRepository.findByUsername(username).orElseThrow(UserNotFoundException::new);

--- a/src/main/java/project/como/global/common/model/RedisDao.java
+++ b/src/main/java/project/como/global/common/model/RedisDao.java
@@ -1,0 +1,46 @@
+package project.como.global.common.model;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisDao {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    public void setValuesList(String key, String data) {
+        redisTemplate.opsForList().rightPushAll(key, data);
+        redisTemplate.expire(key, Duration.ofMinutes(24 * 60L));
+    }
+
+    public List<String> getValuesList(String key) {
+        Long length = redisTemplate.opsForList().size(key);
+
+        return length == 0 ? new ArrayList<>() : redisTemplate.opsForList().range(key, 0, length - 1);
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    public String getValues(String key) {
+        ValueOperations<String, String> values = redisTemplate.opsForValue();
+
+        return values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/project/como/global/config/RedisConfig.java
+++ b/src/main/java/project/como/global/config/RedisConfig.java
@@ -5,20 +5,32 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig {
 
 	@Value("${spring.data.redis.host}")
-	private String redisHost;
+	private String host;
 
 	@Value("${spring.data.redis.port}")
-	private int redisPort;
+	private int port;
 
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(redisHost, redisPort);
+		return new LettuceConnectionFactory(host, port);
+	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+		return redisTemplate;
 	}
 }

--- a/src/main/java/project/como/global/config/RestTemplateConfig.java
+++ b/src/main/java/project/como/global/config/RestTemplateConfig.java
@@ -1,0 +1,27 @@
+package project.como.global.config;
+
+import java.nio.charset.StandardCharsets;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.BufferingClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder
+                .requestFactory(
+                        () -> new BufferingClientHttpRequestFactory(
+                                new SimpleClientHttpRequestFactory()
+                        )
+                ).additionalMessageConverters(
+                        new StringHttpMessageConverter(
+                                StandardCharsets.UTF_8
+                        )).build();
+    }
+}

--- a/src/test/java/project/como/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/project/como/domain/post/controller/PostControllerTest.java
@@ -72,10 +72,11 @@ class PostControllerTest {
 	@DisplayName("게시물 단건 조회")
 	void getDetailPost() {
 		final Long POST_ID = 1L;
+		final String USERNAME = "smc9919";
 
 		Post findPost = em.find(Post.class, POST_ID);
 
-		PostDetailResponseDto servicePostDto = postService.getById(POST_ID);
+		PostDetailResponseDto servicePostDto = postService.getById(POST_ID, USERNAME);
 
 		assertThat(findPost.getTitle()).isEqualTo(servicePostDto.getTitle());
 		assertThat(findPost.getBody()).isEqualTo(servicePostDto.getBody());


### PR DESCRIPTION
## 개요
<!--- 변경  사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. 게시물 페이징 조회, 단건 조회 시 게시물 조회수 반환
2. 게시물 단건 조회 시 조회수 카운팅
3. 조회수 카운팅 중복으로 되는 것을 방지하기 위해 Redis를 이용하여 Key: User, Value:PostId를 리스트로 저장하여 24시간동안 Redis에 해당 PostId를 저장하고 있을 때 카운트 되지 않도록 하였음.

<!---- Resolves: #(Issue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. [Commit message convention](https://jane-aeiou.tistory.com/93) 참고
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
